### PR TITLE
fixed typo to renton wa

### DIFF
--- a/dashboard/Metrics/timescript.html
+++ b/dashboard/Metrics/timescript.html
@@ -61,7 +61,7 @@
            <option value = 'data.princegeorgescountymd.gov'>data.princegeorgescountymd.gov</option>
            <option value = 'data.providenceri.gov'>data.providenceri.gov</option>
            <option value = 'data.raleighnc.gov'>data.raleighnc.gov</option>
-           <option value = 'data.rentonwa.gov'>ata.rentonwa.gov</option>
+           <option value = 'data.rentonwa.gov'>data.rentonwa.gov</option>
            <option value = 'data.seattle.gov'>data.seattle.gov</option>
            <option value = 'data.sfgov.org'>data.sfgov.org</option>
            <option value = 'data.strathcona.ca'>data.strathcona.ca</option>


### PR DESCRIPTION
Changed display of Renton WA from 'ata.rentonwa.gov' to 'data.rentonwa.gov'

<img width="229" alt="screen shot 2016-05-02 at 10 53 33 am" src="https://cloud.githubusercontent.com/assets/7535465/14957620/3bdaf818-1054-11e6-8fb6-16596a66f28b.png">
